### PR TITLE
Add mobile release workflow

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,118 @@
+name: Mobile Release CI
+
+on:
+  push:
+    tags:
+      - 'mobile-v*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-20.04
+    outputs:
+      release_id: ${{ steps.create-release.outputs.result }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: get version
+        run: echo "PACKAGE_VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_ENV
+      - name: create release
+        id: create-release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `mobile-v${process.env.PACKAGE_VERSION}`,
+              name: `カクヨムDownloader Mobile v${process.env.PACKAGE_VERSION}`,
+              body: 'Mobile release build',
+              draft: true,
+              prerelease: false
+            })
+
+            return data.id
+
+  build-android:
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi
+      - name: setup android
+        uses: android-actions/setup-android@v3
+      - name: install dependencies
+        run: yarn && yarn build
+      - name: install tauri cli
+        run: npm install -g @tauri-apps/cli
+      - name: build apk
+        run: tauri android build --ci
+      - name: upload android apk
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: src-tauri/gen/android/app/build/outputs/**/*.apk
+          tag: mobile-v${{ env.PACKAGE_VERSION }}
+          file_glob: true
+          overwrite: true
+
+  build-ios:
+    needs: create-release
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios
+      - name: install dependencies
+        run: yarn && yarn build
+      - name: install tauri cli
+        run: npm install -g @tauri-apps/cli
+      - name: build ios app
+        run: tauri ios build --ci
+      - name: upload ios ipa
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: src-tauri/gen/ios/target/release/bundle/ipa/*.ipa
+          tag: mobile-v${{ env.PACKAGE_VERSION }}
+          file_glob: true
+          overwrite: true
+
+  publish-release:
+    runs-on: ubuntu-20.04
+    needs: [ create-release, build-android, build-ios ]
+    steps:
+      - name: publish release
+        id: publish-release
+        uses: actions/github-script@v6
+        env:
+          release_id: ${{ needs.create-release.outputs.release_id }}
+        with:
+          script: |
+            github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: process.env.release_id,
+              draft: false,
+              prerelease: false
+            })


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for Android and iOS release

## Testing
- `act -l`
- `act -n -W .github/workflows/mobile.yml -j build-android` *(fails: Could not connect to Docker)*


------
https://chatgpt.com/codex/tasks/task_e_6840309cd0f083269281752e93ac336c